### PR TITLE
fixed Python2-specific behavior in exception decorator

### DIFF
--- a/gems/decorators.py
+++ b/gems/decorators.py
@@ -103,6 +103,6 @@ def exception(exception):
             try:
                 return func(*args, **kwargs)
             except Exception as exe:
-                raise exception, exe, sys.exc_info()[2]
+                raise exception(exe, sys.exc_info()[2])
         return wrapper
     return decorator


### PR DESCRIPTION
When importing `gems` v. 0.2.3 from Python 3:

```
  File "/...../gems/decorators.py", line 106
    raise exception, exe, sys.exc_info()[2]
                   ^
SyntaxError: invalid syntax
```

Created a one-liner patch to `decorators.py` to conform to Python 3 behavior. 

- All Python 2.7 tests pass 
- All Python 3.X test pass (except for the metaclass test)